### PR TITLE
Fix children definition in FlexItem

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -37,7 +37,11 @@ export interface BoxProps {
     children?: ReactNode,
 }
 
-export interface FlexBoxProps {
+export interface FlexBoxProps extends FlexBoxUniqueProps {
+    children?: ReactNode,
+}
+
+export interface FlexBoxUniqueProps {
     inline?: boolean,
     wrap?: boolean,
     wrapReverse?: boolean,
@@ -51,7 +55,6 @@ export interface FlexBoxProps {
     gap?: CSSProperties['gap'],
     columnGap?: CSSProperties['columnGap'],
     rowGap?: CSSProperties['rowGap'],
-    children?: ReactNode,
 }
 
 export interface FlexItemBaseProps {
@@ -68,4 +71,4 @@ export interface FlexItemBaseProps {
 
 export type FlexItemProps =
     | FlexItemBaseProps & { box: true} & FlexBoxProps
-    | FlexItemBaseProps & { box?: false } & Never<FlexBoxProps>;
+    | FlexItemBaseProps & { box?: false } & Never<FlexBoxUniqueProps>;


### PR DESCRIPTION
The current `FlexItem` prop definition is broken: it does not allow it to have `children` because `children` is also defined in `FlexBoxProps`.  This is a quick fix I made to solve the problem but you may have a better suggestion how to structure it in a nicer way.